### PR TITLE
Common APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "superagent": "^1.2.0",
     "vasync": "~1.6.2"
   },
-  "homepage": "https://github.com/j3k0/ganomede-helpers"
+  "homepage": "https://github.com/j3k0/ganomede-helpers",
+  "devDependencies": {
+    "supertest": "^1.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ganomede-helpers",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Helper modules shared by ganomede microservices",
   "main": "index.js",
   "scripts": {

--- a/src/apis/about.coffee
+++ b/src/apis/about.coffee
@@ -1,0 +1,30 @@
+# About
+
+os = require "os"
+path = require "path"
+
+defaultAbout = () ->
+  # So we don't read helpers package.json, but main package.json.
+  pk = require(path.join(process.cwd(), 'package.json'))
+
+  return {
+    hostname: os.hostname()
+    type: pk.name
+    version: pk.version
+    description: pk.description
+    startDate: (new Date).toISOString()
+  }
+
+module.exports = (options={}) ->
+  about = options.about || defaultAbout()
+
+  sendAbout = (req, res, next) ->
+    res.json(about)
+    next()
+
+  api = (prefix, server) ->
+    server.get "/about", sendAbout
+    server.get "/#{prefix}/about", sendAbout
+
+  api.about = about
+  return api

--- a/src/apis/index.coffee
+++ b/src/apis/index.coffee
@@ -1,0 +1,3 @@
+module.exports =
+  about: require './about'
+  ping: require './ping'

--- a/src/apis/ping.coffee
+++ b/src/apis/ping.coffee
@@ -1,0 +1,11 @@
+ping = (req, res, next) ->
+  res.contentType = 'text'
+  res.send("pong/#{req.params.token}")
+  next()
+
+module.exports = () ->
+  return (prefix, server) ->
+    server.get "/#{prefix}/ping/:token", ping
+    server.head "/#{prefix}/ping/:token", ping
+
+# vim: ts=2:sw=2:et:

--- a/src/restify/index.coffee
+++ b/src/restify/index.coffee
@@ -1,2 +1,3 @@
 module.exports =
   middlewares: require './middlewares'
+  createServer: require './server'

--- a/src/restify/server.coffee
+++ b/src/restify/server.coffee
@@ -1,0 +1,10 @@
+restify = require 'restify'
+
+module.exports = (options={}) ->
+  server = restify.createServer()
+
+  server.use restify.queryParser()
+  server.use restify.bodyParser()
+  server.use restify.gzipResponse()
+
+  return server

--- a/tests/apis/test-about-api.coffee
+++ b/tests/apis/test-about-api.coffee
@@ -2,12 +2,13 @@ expect = require 'expect.js'
 supertest = require 'supertest'
 restify = require 'restify'
 aboutApi = require '../../src/apis/about'
+restifyAddons = require '../../src/restify'
 
 CUSTOM_PREFIX = 'custom-prefix'
 CUSTOM_ABOUT = {custom: true}
 
 describe 'About API', () ->
-  server = restify.createServer()
+  server = restifyAddons.createServer()
   api = aboutApi()
   go = supertest.bind(supertest, server)
 

--- a/tests/apis/test-about-api.coffee
+++ b/tests/apis/test-about-api.coffee
@@ -1,0 +1,34 @@
+expect = require 'expect.js'
+supertest = require 'supertest'
+restify = require 'restify'
+aboutApi = require '../../src/apis/about'
+
+CUSTOM_PREFIX = 'custom-prefix'
+CUSTOM_ABOUT = {custom: true}
+
+describe 'About API', () ->
+  server = restify.createServer()
+  api = aboutApi()
+  go = supertest.bind(supertest, server)
+
+  before (done) ->
+    api(CUSTOM_PREFIX, server)
+    server.listen(1337, done)
+
+  after (done) ->
+    server.close(done)
+
+  it 'supports custom about field', () ->
+    customAboutApi = aboutApi({about: CUSTOM_ABOUT})
+    expect(customAboutApi.about).to.eql(CUSTOM_ABOUT)
+
+  describe 'GET-ing about info', () ->
+    it 'GET /about', (done) ->
+      go()
+        .get '/about'
+        .expect 200, api.about, done
+
+    it 'GET #{prefix}/about', (done) ->
+      go()
+        .get "/#{CUSTOM_PREFIX}/about"
+        .expect 200, api.about, done

--- a/tests/apis/test-ping-api.coffee
+++ b/tests/apis/test-ping-api.coffee
@@ -1,10 +1,11 @@
 restify = require 'restify'
 supertest = require 'supertest'
 pingApi = require '../../src/apis/ping'
+restifyAddons = require '../../src/restify'
 
 describe 'Ping API', () ->
   api = pingApi()
-  server = restify.createServer()
+  server = restifyAddons.createServer()
   go = supertest.bind(supertest, server)
   prefix = 'some-prefix'
   token = 'some-token'

--- a/tests/apis/test-ping-api.coffee
+++ b/tests/apis/test-ping-api.coffee
@@ -1,0 +1,30 @@
+restify = require 'restify'
+supertest = require 'supertest'
+pingApi = require '../../src/apis/ping'
+
+describe 'Ping API', () ->
+  api = pingApi()
+  server = restify.createServer()
+  go = supertest.bind(supertest, server)
+  prefix = 'some-prefix'
+  token = 'some-token'
+  endpoint = "/#{prefix}/ping/#{token}"
+  expectedResponse = "pong/#{token}"
+
+  before (cb) ->
+    api(prefix, server)
+    server.listen(1337, cb)
+
+  after (cb) ->
+    server.close(cb)
+
+  describe '/#{prefix}/ping', () ->
+    it 'GET', (done) ->
+      go()
+        .get(endpoint)
+        .expect(200, expectedResponse, done)
+
+    it 'HEAD', (done) ->
+      go()
+        .head(endpoint)
+        .expect(200, done)


### PR DESCRIPTION
Adding common APIs (route mounters `(prefix, server)`) to ganomede-helpers so we don't need to copy-paste stuff like `/about` and `/ping` with their tests.

(I started working on `virtualcurrency` module and didn't feel like copying stuff over, are you ok with this @j3k0?)
